### PR TITLE
修改str为元素id/模板字符串的检测逻辑，增加nodejs支持

### DIFF
--- a/baiduTemplate.js
+++ b/baiduTemplate.js
@@ -8,9 +8,9 @@
 */
 
 ;(function(){
-    var space = (typeof module !== 'undefined' && module.exports) || function() { return this; }();
     //取得命名空间 baidu.template
-    var baidu=space.baidu=space.baidu||{};
+    //nodejs下用module.exports，浏览器下用window，但考虑有其他环境（如phantomjs或wcript）存在，使用this获取全局对象
+    var baidu = typeof module === 'undefined' ? (this.baidu = this.baidu || {}) : module.exports;
 
     //模板函数
     var bt = function(str, data){
@@ -19,7 +19,7 @@
         //@see http://dev.w3.org/html5/markup/datatypes.html#common.data.id-def
         var fn = (function() {
             //后端环境没有document
-            if (!space.document) {
+            if (!this.document) {
                 return compile(str);
             }
 

--- a/baiduTemplate.js
+++ b/baiduTemplate.js
@@ -8,14 +8,21 @@
 */
 
 ;(function(){
+    var space = (typeof module !== 'undefined' && module.exports) || function() { return this; }();
+    //取得命名空间 baidu.template
+    var baidu=space.baidu=space.baidu||{};
 
     //模板函数
     var bt = function(str, data){
-
         //检查是否有该id的元素存在，如果有元素则获取元素的innerHTML/value，否则认为字符串为模板
         //HTML5规定ID可以由任何不包含空格字符的字符串组成，因此无法通过正则检测一个字符串是否为元素ID
         //@see http://dev.w3.org/html5/markup/datatypes.html#common.data.id-def
         var fn = (function() {
+            //后端环境没有document
+            if (!space.document) {
+                return compile(str);
+            }
+
             var element = document.getElementById(str);
             if (element) {
                 //由于使用DOM元素作为模板容器的情况下，使用的模板数量不会太多，因此会对模板编译后的函数进行缓存
@@ -36,9 +43,6 @@
         //有数据则返回HTML字符串，没有数据则返回函数
         return data ? fn( data ) : fn;
     };
-
-    //取得命名空间 baidu.template
-    baidu=window.baidu||{};
     baidu.template=bt;
 
     //缓存  将对应id模板生成的函数缓存下来。


### PR DESCRIPTION
1. 修改str为元素id/模板字符串的检测逻辑
   
   HTML5对元素ID的规定与HTML4不同，无法通过正则进行检测，详见[此处](http://dev.w3.org/html5/markup/datatypes.html#common.data.id-def)
   
   因此考虑先尝试通过字符串获取元素，如果不存在以此字符串为id的元素则认为字符串是模板
   
   由于getElementById在时间复杂度为**O(1)**，消耗为Javascript引擎与DOM的交互产生的额外消耗，基本可以忽略不计，与正则检测相比，可以认为不存在性能差异（无性能测试用例和数据，无法给出精确结果，见谅）
2. 支持nodejs
   
   README中的使用场景有介绍后端javascript模板可以使用baiduTemplate，但事实上原有实现因为2个问题根本无法在后端运行
   1. 将导出的`baidu`对象放在**全局环境**下
   2. 严重依赖`document`对象
   
   因此修改逻辑，使之可以支持nodejs环境，同时尽可能兼容其他后端javascript环境

如果该逻辑与模板实现原有思想相背，请关闭此Pull Request

另：没有足够的测试用例的项目很难由社区给予贡献（不知道修改的内容是否符合pull request的要求），是否把测试用例的补充放在文档的细节修改之前？
