### PR TITLE
将模版参数data改为__data__

### DIFF
--- a/baiduTemplate.js
+++ b/baiduTemplate.js
@@ -101,7 +101,7 @@
 
     //将字符串拼接生成函数，即编译过程(compile)
     bt._compile = function(str){
-        var funBody = "var _template_fun_array=[];\nvar fn=(function(data){\nvar _template_varName='';\nfor(name in data){\n_template_varName+=('var '+name+'=data[\"'+name+'\"];');\n};\neval(_template_varName);\n_template_fun_array.push('"+bt._analysisStr(str)+"');\n_template_varName=null;\n})(_template_object);\nfn = null;\nreturn _template_fun_array.join('');\n";
+        var funBody = "var _template_fun_array=[];\nvar fn=(function(__data__){\nvar _template_varName='';\nfor(name in __data__){\n_template_varName+=('var '+name+'=__data__[\"'+name+'\"];');\n};\neval(_template_varName);\n_template_fun_array.push('"+bt._analysisStr(str)+"');\n_template_varName=null;\n})(_template_object);\nfn = null;\nreturn _template_fun_array.join('');\n";
         return new Function("_template_object",funBody);
     };
 


### PR DESCRIPTION
将模版参数data改为**data**。
使用data，如果传递进来的数据还有data作为key的话，会把后面的值冲掉，如：
baidu.template(html, {
    data: [{}, {}],
    otherkey: "othervalue"
})
这样的话就获取不到otherkey了，所以将data改为**data**，**data**一般不会在数据key中出现，可以避免。
