### PR TITLE
没有 var name 变量，导致 window.name 被污染

### DIFF
--- a/baiduTemplate.js
+++ b/baiduTemplate.js
@@ -105,7 +105,7 @@
 
     //将字符串拼接生成函数，即编译过程(compile)
     bt._compile = function(str){
-        var funBody = "var _template_fun_array=[];\nvar fn=(function(__data__){\nvar _template_varName='';\nfor(name in __data__){\n_template_varName+=('var '+name+'=__data__[\"'+name+'\"];');\n};\neval(_template_varName);\n_template_fun_array.push('"+bt._analysisStr(str)+"');\n_template_varName=null;\n})(_template_object);\nfn = null;\nreturn _template_fun_array.join('');\n";
+        var funBody = "var _template_fun_array=[];\nvar fn=(function(__data__){\nvar _template_varName='';\nfor(var name in __data__){\n_template_varName+=('var '+name+'=__data__[\"'+name+'\"];');\n};\neval(_template_varName);\n_template_fun_array.push('"+bt._analysisStr(str)+"');\n_template_varName=null;\n})(_template_object);\nfn = null;\nreturn _template_fun_array.join('');\n";
         return new Function("_template_object",funBody);
     };
 


### PR DESCRIPTION
也就是 name 声明成全局变量了，而不是局部变量。
