### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,28 @@
 
 ### ==========================
 
-###文档请查看官网
+### 文档请查看官网
 
 <a href="http://baidufe.github.com/BaiduTemplate/">http://baidufe.github.com/BaiduTemplate/</a>
 
 
-###change log
+### change log
 
-###1.0.6：
+### 1.0.6：
 	重构代码，修改定义变量的bug，增加对版本号的标注 baidu.template.versions
 
-###1.0.5：
+### 1.0.5：
 	修改可能造成内存泄露的变量及方法直接挂在baidu.template命名空间下
 
-###1.0.4：
+### 1.0.4：
 	经过第三方测试反馈，进行对编译后产生的函数性能优化，性能提高1/3以上
 
-###1.0.3：
+### 1.0.3：
 	通过产品线反馈，经过讨论增加自定义是否默认转义接口 baidu.template.ESCAPE
 
-###1.0.2：
+### 1.0.2：
 	优化正则，提升性能，修复bug，支持nodejs，支持npm install baidutemplate可以安装
 
-###1.0.1：
+### 1.0.1：
 	优化正则，提升性能，修复bug
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
